### PR TITLE
v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.1
+
+- Self check URL now handled by `shelf_letsencrypt`:
+  - Using path: `/.well-known/check/`
+
 ## 1.1.0
 
 - `README.md`: fix Dart CI badge

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shelf_letsencrypt
 description: Let's Encrypt support for the shelf package (free and automatic HTTPS certificate support).
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/gmpassos/shelf_letsencrypt
 
 environment:

--- a/test/shelf_letsencrypt_test.dart
+++ b/test/shelf_letsencrypt_test.dart
@@ -92,7 +92,16 @@ void main() {
           LetsEncrypt.isACMEPath(
               '/.well-known/acme-challenge/Y73s3McbchxLs_NklRfW6HebjYrBmbVeKm0c9jbn3QI'),
           isTrue);
+
+      expect(
+          LetsEncrypt.isWellknownPath(
+              '/.well-known/acme-challenge/Y73s3McbchxLs_NklRfW6HebjYrBmbVeKm0c9jbn3QI'),
+          isTrue);
+
+      expect(LetsEncrypt.isACMEPath('/.well-known/foo/123'), isFalse);
+
       expect(LetsEncrypt.isACMEPath('/well-known/'), isFalse);
+      expect(LetsEncrypt.isWellknownPath('/well-known/'), isFalse);
       expect(LetsEncrypt.isACMEPath('/any/path'), isFalse);
 
       {
@@ -113,6 +122,31 @@ void main() {
         // No challenge token expected:
         var response = letsEncrypt.processACMEChallengeRequest(request);
         expect(response.statusCode, equals(404));
+      }
+    });
+
+    test('Self check path', () async {
+      var certificatesHandler = CertificatesHandlerIO(
+          Directory(pack_path.join(tmpDir.path, 'certs-3')));
+
+      var letsEncrypt = LetsEncrypt(certificatesHandler);
+
+      expect(
+          LetsEncrypt.isWellknownPath('/.well-known/check/123456789'), isTrue);
+
+      expect(
+          LetsEncrypt.isSelfCheckPath('/.well-known/check/123456789'), isTrue);
+
+      expect(LetsEncrypt.isSelfCheckPath('/well-known/'), isFalse);
+      expect(LetsEncrypt.isWellknownPath('/well-known/'), isFalse);
+      expect(LetsEncrypt.isSelfCheckPath('/any/path'), isFalse);
+
+      {
+        var uri = Uri.parse('http://foo.com/.well-known/check/123456789');
+        var request = Request('GET', uri, headers: {'host': 'foo.com'});
+
+        var response = letsEncrypt.processSelfCheckRequest(request);
+        expect(response.statusCode, equals(200));
       }
     });
 


### PR DESCRIPTION
- Self check URL now handled by `shelf_letsencrypt`:
  - Using path: `/.well-known/check/`