### PR TITLE
implemented support for dns-persist-01

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ pubspec.lock
 
 .history
 .failed_tracker
-pubspec.yaml
 logs/analyzer.txt
 .mcp_logs
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ pubspec.lock
 
 .history
 .failed_tracker
+pubspec.yaml
+logs/analyzer.txt
+.mcp_logs

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ coverage/
 # Omit committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
+pubspec_overrides.yaml
 
 .history
 .failed_tracker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.2.0
+
+- added `LetsEncrypt.prepareDnsPersistCertificateRequest(...)` for a manual
+  two-phase `dns-persist-01` flow
+- added `PendingDnsPersistRequest`
+- added the `shelf_letsencrypt_dns_persist` CLI helper
+
+## 2.1.0
+
+- migrated to `acme_client` v2
+- added support for `dns-persist-01` via `LetsEncryptChallengeType.dnsPersist`
+
 ## 2.0.3
 
 - multi_domain_secure_server: ^1.0.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 - added `LetsEncrypt.prepareDnsPersistCertificateRequest(...)` for a manual
   two-phase `dns-persist-01` flow
 - added `PendingDnsPersistRequest`
+- made `PendingDnsPersistRequest.complete()` idempotent for repeated and
+  concurrent calls
+- added `PendingDnsPersistRequest.complete(timeout: ...)` so timed-out manual
+  completions can be retried
+- allow automated `dns-persist-01` requests without
+  `dnsPersistChallengePublisher` when `selfTest` is enabled and the persistent
+  TXT record already exists
+- added `PendingDnsPersistRequest.complete(forceRequestCertificate: true)` and
+  `shelf_letsencrypt_dns_persist --force-request-certificate` to force
+  certificate recreation
+- changed the default renewal threshold to one third of the certificate
+  lifetime, capped at 30 days
 - added the `shelf_letsencrypt_dns_persist` CLI helper
 
 ## 2.1.0

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
 
 [letsencrypt]: https://letsencrypt.org/
 
+`dns-persist-01` is the recommended challenge type when your ACME CA supports
+it. It avoids serving transient HTTP challenge files and is designed for a
+stable delegated DNS TXT record tied to your ACME account.
+
 # Developing with shelf_letsencrypt
 LetsEncrypt provide a few challenges for your development enviroment. 
 Read on for a few hints.
@@ -127,6 +131,11 @@ void main(List<String> args) async {
     production: false, // If `true` uses Let's Encrypt production API.
     port: 80,
     securePort: 443,
+    // For automated dns-persist-01 use:
+    // challengeType: LetsEncryptChallengeType.dnsPersist,
+    // dnsPersistChallengePublisher: (domainName, proof) async {
+    //   print('Publish ${proof.txtRecordName} = ${proof.txtRecordValue}');
+    // },
   );
 
   var servers = await _startServer(letsEncrypt, domains);
@@ -215,6 +224,36 @@ The example includes a renewal service that does a daily check if any certificat
 need renewing.
 If a cert needs to be renewed, it will renew it and then gracefully restart
 the server with the new certs.
+
+## Manual dns-persist-01 flow
+
+If you cannot publish DNS records automatically, prepare the request first,
+show the TXT record to an operator, and only continue once the record has been
+published:
+
+```dart
+final pending = await letsEncrypt.prepareDnsPersistCertificateRequest(
+  const Domain(name: 'example.com', email: 'contact@example.com'),
+);
+
+print(pending.proof.txtRecordName);
+print(pending.proof.txtRecordValue);
+
+// Wait for the operator to publish the TXT record...
+final ok = await pending.complete();
+```
+
+The package also ships a small CLI for this flow:
+
+```sh
+dart run shelf_letsencrypt_dns_persist \
+  --domain example.com \
+  --email contact@example.com \
+  --cert-dir ./certs
+```
+
+The CLI prints the TXT record, waits for confirmation, then validates and
+stores the issued certificate in the chosen certificate directory.
 
 ## Source
 

--- a/README.md
+++ b/README.md
@@ -22,27 +22,27 @@ it. It avoids serving transient HTTP challenge files and is designed for a
 stable delegated DNS TXT record tied to your ACME account.
 
 # Developing with shelf_letsencrypt
-LetsEncrypt provide a few challenges for your development enviroment. 
+Let's Encrypt provides a few challenges for your development environment.
 Read on for a few hints.
 
 ## A word of caution
-LetsEncrypt rate limits the issuing of production certificates.
-It is very easy to get locked out of letsencrypt for an extended period of time (days)
+Let's Encrypt rate-limits the issuing of production certificates.
+It is very easy to get locked out of Let's Encrypt for an extended period of time (days),
 leaving you in the situation where you can't issue a production certificate.
 
 CRITICAL: you could end up with your production systems down for days!!!!
 
-I would advise you to read up on the Lets Encrypt rate limits:
+I would advise you to read up on the Let's Encrypt rate limits:
 
 https://letsencrypt.org/docs/rate-limits/
 
-To avoid this (potentially) major issue make certain that you test with a STAGING
+To avoid this potentially major issue, make certain that you test with a STAGING
 certificate.
 
 
-You do this by passing in 'production: false' (the default) when creating
+Do this by passing in 'production: false' (the default) when creating
 the LetsEncrypt certificate.
-Staging certificates still have rate limits but they are much more generours
+Staging certificates still have rate limits, but they are much more generous.
 
 ```dart 
 final LetsEncrypt letsEncrypt = LetsEncrypt(certificatesHandler, production: false);
@@ -54,47 +54,50 @@ On Linux you need to be root (sudo) to open a port below 1024. If you try
 to start your server with the default ports (80, 443) you will fail.
 
 
-## NAT for your Development environment
-To issue a certificate LetsEncrypt needs to be able to connect to your
-webserver on port 80.
-This will work fine in production (with the write firewall rules) but in 
+## NAT for your development environment
+To issue a certificate, Let's Encrypt needs to be able to connect to your
+web server on port 80.
+This will work fine in production (with the right firewall rules), but in
 a development environment can be a bit tricky.
 
-The above Permission limitations add to the complication. 
+The above permission limitations add to the complication.
 
-The easist way to do this is (for dev):
-1) start your server on ports 8080 and 8443 (or any pair above 1024)
-2) set up two NATS on your router that forward ports to your dev machine.
+The easiest way to do this is (for dev):
+1. Start your server on ports 8080 and 8443 (or any pair above 1024).
+2. Set up two NAT rules on your router that forward ports to your dev machine:
    80 -> 8080
    443 -> 8443
 
 
 ## DNS for development
-For Lets Encrypt to issue a certificate it must be able to resolve the domain
+For Let's Encrypt to issue a certificate, it must be able to resolve the domain
 name of the certificate that you are requesting.
 
-To avoid tampering with your production DNS I keep a cheap domain name that I 
-use in test. 
-I then use cloudflare's free DNS hosting service to host the domain name which
-allows me to add the necessary A record which points to my WFH router on which
-I've configured the above NAT.
+To avoid tampering with your production DNS, I keep a cheap domain name that I
+use for testing.
+I then use Cloudflare's free DNS hosting service to host the domain name, which
+allows me to add the necessary A record pointing to my WFH router, where I've
+configured the above NAT.
 
 ## Multi-Domain Support
-Starting with `shelf_letsencrypt: 2.0.0`, support for multiple domains on the same HTTPS port has been introduced. This
-enhancement allows `shelf_letsencrypt` to manage certificate requests and automatically serve multiple domains
-seamlessly.
+Starting with `shelf_letsencrypt: 2.0.0`, support for multiple domains on the
+same HTTPS port has been introduced. This enhancement allows
+`shelf_letsencrypt` to manage certificate requests and automatically serve
+multiple domains seamlessly.
 
-This functionality is powered by the [multi_domain_secure_server][pub_multi_domain_secure_server] package (developed
-by [gmpassos][github_gmpassos]), specifically created for `shelf_letsencrypt`. It enables a `SecureServerSocket` to handle
-different `SecurityContext` (certificates) on the same listening port. For more details, check out the source code
-on [GitHub][github_multi_domain_secure_server].
+This functionality is powered by the
+[multi_domain_secure_server][pub_multi_domain_secure_server] package (developed
+by [gmpassos][github_gmpassos]), specifically created for
+`shelf_letsencrypt`. It enables a `SecureServerSocket` to handle different
+`SecurityContext` instances (certificates) on the same listening port. For more
+details, check out the source code on [GitHub][github_multi_domain_secure_server].
 
 [pub_multi_domain_secure_server]: https://pub.dev/packages/multi_domain_secure_server
 [github_multi_domain_secure_server]: https://github.com/gmpassos/multi_domain_secure_server
 
 # Usage
 
-To use the `LetsEncrypt` class
+To use the `LetsEncrypt` class:
 
 ```dart
 import 'dart:io';
@@ -103,8 +106,8 @@ import 'package:cron/cron.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf_letsencrypt/shelf_letsencrypt.dart';
 
-/// Start the example with a list of domains and a reciprocal
-/// e-mail address for the domain admin:
+/// Start the example with a list of domains and the corresponding
+/// email address for each domain admin:
 /// ```dart
 /// dart shelf_letsencrypt_example.dart \
 ///     www.domain.com:www2.domain.com \
@@ -112,7 +115,7 @@ import 'package:shelf_letsencrypt/shelf_letsencrypt.dart';
 /// ```
 void main(List<String> args) async {
   final domainNamesArg = args[0]; // Domains for the HTTPS certificate.
-  final domainEmailsArg = args[1]; // The domains e-mail.
+  final domainEmailsArg = args[1]; // The domains' email addresses.
 
   var certificatesDirectory = args.length > 2
       ? args[2] // Optional argument.
@@ -121,7 +124,7 @@ void main(List<String> args) async {
   final domains =
   Domain.fromDomainsNamesAndEmailsArgs(domainNamesArg, domainEmailsArg);
 
-  // The Certificate handler, storing at `certificatesDirectory`.
+  // The certificate handler, storing at `certificatesDirectory`.
   final certificatesHandler =
   CertificatesHandlerIO(Directory(certificatesDirectory));
 
@@ -214,14 +217,14 @@ Response _processRequest(Request request) =>
 
 ## Renewals
 
-Each time your call startServer it will check if any certificates need to
+Each time you call `startServer`, it will check if any certificates need to
 be renewed in the next 5 days (or if they are expired) and renew the
-certificate.
+certificates.
 
-This however isn't sufficient for any long running service.
+This, however, isn't sufficient for any long-running service.
 
-The example includes a renewal service that does a daily check if any certificate
-need renewing.
+The example includes a renewal service that does a daily check to see if any
+certificates need renewing.
 If a cert needs to be renewed, it will renew it and then gracefully restart
 the server with the new certs.
 
@@ -274,8 +277,8 @@ Please file feature requests and bugs at the [issue tracker][tracker].
 Any help from the open-source community is always welcome and needed:
 
 - Found an issue?
-    - Please fill a bug report with details.
-- Wish a feature?
+    - Please file a bug report with details.
+- Want a feature?
     - Open a feature request with use cases.
 - Are you using and liking the project?
     - Promote the project: create an article, do a post or make a donation.
@@ -286,8 +289,8 @@ Any help from the open-source community is always welcome and needed:
 - Have you already helped in any way?
     - **Many thanks from me, the contributors and everybody that uses this project!**
 
-*If you donate 1 hour of your time, you can contribute a lot, because others will do the same, just be part and start
-with your 1 hour.*
+*If you donate 1 hour of your time, you can contribute a lot. Others will do
+the same; just be part of it and start with your 1 hour.*
 
 # TODO
 
@@ -297,7 +300,7 @@ with your 1 hour.*
 # Author
 
 Graciliano M. Passos: [gmpassos@GitHub][github_gmpassos].
-Brett Sutton [bsutton@GitHub][github_bsutton]
+Brett Sutton: [bsutton@GitHub][github_bsutton].
 
 [github_gmpassos]: https://github.com/gmpassos
 [github_bsutton]: https://github.com/bsutton

--- a/README.md
+++ b/README.md
@@ -16,10 +16,16 @@
 [shelf_package]: https://pub.dev/packages/shelf
 
 [letsencrypt]: https://letsencrypt.org/
+[letsencrypt_dns_persist_status]: https://letsencrypt.org/2026/02/18/dns-persist-01
+[letsencrypt_dns_persist_deployment]: https://community.letsencrypt.org/t/dns-persist-01-deployment-status-and-timeline/246468
 
 `dns-persist-01` is the recommended challenge type when your ACME CA supports
-it. It avoids serving transient HTTP challenge files and is designed for a
-stable delegated DNS TXT record tied to your ACME account.
+it. It avoids serving transient HTTP challenge files, keeps your development
+machine private, and is designed for a stable delegated DNS TXT record tied to
+your ACME account. Let's Encrypt is rolling out support for this challenge; see
+their [DNS-PERSIST-01 status post][letsencrypt_dns_persist_status] and the
+[deployment status thread][letsencrypt_dns_persist_deployment] before relying on
+it for production issuance.
 
 # Developing with shelf_letsencrypt
 ACME certificate authorities use challenges to prove that you control the
@@ -53,7 +59,35 @@ final LetsEncrypt letsEncrypt = LetsEncrypt(certificatesHandler, production: fal
 
 ## Challenge mechanisms
 
-### http-01
+### dns-persist-01 (recommended where supported)
+
+`dns-persist-01` proves control of the domain with a stable delegated DNS TXT
+record rather than an inbound HTTP request. Use it when your ACME CA supports
+the challenge and you can publish the required TXT record.
+
+Development implications:
+
+- Your development server does not need to be reachable from the public internet
+  for certificate issuance.
+- NAT and inbound port forwarding are not required for the ACME challenge.
+- You need control of the domain's DNS, or a delegated validation name, so the
+  TXT record can be published.
+- DNS publication can be automated with `dnsPersistChallengePublisher`, or you
+  can use `prepareDnsPersistCertificateRequest(...)` for a manual operator flow.
+- The issued certificate is still for the requested domain, so your application
+  DNS and routing still need to make sense for however you plan to serve the app
+  after the certificate is issued.
+
+This mode is the better fit for most development environments because the laptop
+or workstation can stay private. It also avoids coupling certificate issuance to
+home-router NAT, public Wi-Fi, or temporary firewall rules.
+
+Note: Let's Encrypt announced DNS-PERSIST-01 support as a rollout item in
+February 2026. Pebble support is available, but Let's Encrypt production support
+depends on their rollout and the evolving IETF draft. Check the linked Let's
+Encrypt status resources before using this challenge against production.
+
+### http-01 (fallback/default)
 
 `http-01` is the default challenge type. The ACME server validates the request
 by fetching a token from:
@@ -79,29 +113,6 @@ For local testing with `http-01`, I normally use a cheap test domain and point
 its A record at my development router. The router then forwards port 80 to the
 local server port used by the example app.
 
-### dns-persist-01
-
-`dns-persist-01` proves control of the domain with a stable delegated DNS TXT
-record rather than an inbound HTTP request. Use it when your ACME CA supports
-the challenge and you can publish the required TXT record.
-
-Development implications:
-
-- Your development server does not need to be reachable from the public internet
-  for certificate issuance.
-- NAT and inbound port forwarding are not required for the ACME challenge.
-- You need control of the domain's DNS, or a delegated validation name, so the
-  TXT record can be published.
-- DNS publication can be automated with `dnsPersistChallengePublisher`, or you
-  can use `prepareDnsPersistCertificateRequest(...)` for a manual operator flow.
-- The issued certificate is still for the requested domain, so your application
-  DNS and routing still need to make sense for however you plan to serve the app
-  after the certificate is issued.
-
-This mode is the better fit for most development environments because the laptop
-or workstation can stay private. It also avoids coupling certificate issuance to
-home-router NAT, public Wi-Fi, or temporary firewall rules.
-
 ## Multi-Domain Support
 Starting with `shelf_letsencrypt: 2.0.0`, support for multiple domains on the
 same HTTPS port has been introduced. This enhancement allows
@@ -124,7 +135,82 @@ Choose the challenge mechanism first, then wire `LetsEncrypt` for that flow.
 Use `production: false` while testing so certificate requests go to the staging
 ACME endpoint.
 
-### http-01 server flow (default)
+### Recommended: automated dns-persist-01
+
+Use automated `dns-persist-01` when your ACME CA supports the challenge and your
+application can publish DNS TXT records through your DNS provider's API. In this
+mode, `shelf_letsencrypt` prepares the ACME challenge and calls your
+`dnsPersistChallengePublisher` callback with the TXT record that must exist
+before validation continues.
+
+```dart
+final letsEncrypt = LetsEncrypt(
+  certificatesHandler,
+  production: false,
+  challengeType: LetsEncryptChallengeType.dnsPersist,
+  dnsPersistChallengePublisher: (domainName, proof) async {
+    await publishTxtRecord(
+      proof.txtRecordName,
+      proof.txtRecordValue,
+    );
+  },
+);
+```
+
+`publishTxtRecord` is application code that you provide. It should create or
+update the TXT record through your DNS provider and return only when the record
+is ready for validation.
+
+### Manual dns-persist-01 API flow
+
+Use the manual API when a human operator needs to publish the DNS TXT record.
+Prepare the request first, show the TXT record to the operator, and only call
+`complete()` once the record has been published:
+
+```dart
+final pending = await letsEncrypt.prepareDnsPersistCertificateRequest(
+  const Domain(name: 'example.com', email: 'contact@example.com'),
+);
+
+print(pending.proof.txtRecordName);
+print(pending.proof.txtRecordValue);
+print(pending.proof.toBindString());
+
+// Wait for the operator to publish the TXT record...
+final ok = await pending.complete();
+```
+
+`complete()` validates the challenge, finalizes the order, fetches the
+certificate chain, and stores it through the configured `CertificatesHandler`.
+
+### CLI helper for dns-persist-01
+
+The package ships a CLI for the same manual `dns-persist-01` flow:
+
+```sh
+dart run shelf_letsencrypt_dns_persist \
+  --domain example.com \
+  --email contact@example.com \
+  --cert-dir ./certs
+```
+
+The CLI prepares the request, prints the TXT record details, prints a BIND-style
+record line, and waits for confirmation before it asks the ACME server to
+validate the challenge. It does not publish DNS records itself; publish the TXT
+record with your DNS provider before pressing ENTER.
+
+Useful options:
+
+- `--cert-dir <path>` chooses the certificate directory used by
+  `CertificatesHandlerIO`. Use the same directory your app will read from.
+- `--acme-dir <url>` targets a custom ACME directory, such as a local Pebble
+  server.
+- `--production` uses the Let's Encrypt production endpoint. Use it for
+  `dns-persist-01` only when Let's Encrypt production supports the challenge.
+- `--yes` skips the ENTER prompt. Use this only when automation has already
+  published the required TXT record.
+
+### http-01 server flow (fallback/default)
 
 Use `http-01` when the ACME server can reach your app over public HTTP. This is
 the default `LetsEncrypt` mode and is the simplest production setup when port 80
@@ -243,80 +329,6 @@ Response _processRequest(Request request) =>
     Response.ok('Requested: ${request.requestedUri}');
 
 ```
-
-### Automated dns-persist-01
-
-Use automated `dns-persist-01` when your ACME CA supports the challenge and your
-application can publish DNS TXT records through your DNS provider's API. In this
-mode, `shelf_letsencrypt` prepares the ACME challenge and calls your
-`dnsPersistChallengePublisher` callback with the TXT record that must exist
-before validation continues.
-
-```dart
-final letsEncrypt = LetsEncrypt(
-  certificatesHandler,
-  production: false,
-  challengeType: LetsEncryptChallengeType.dnsPersist,
-  dnsPersistChallengePublisher: (domainName, proof) async {
-    await publishTxtRecord(
-      proof.txtRecordName,
-      proof.txtRecordValue,
-    );
-  },
-);
-```
-
-`publishTxtRecord` is application code that you provide. It should create or
-update the TXT record through your DNS provider and return only when the record
-is ready for validation.
-
-### Manual dns-persist-01 API flow
-
-Use the manual API when a human operator needs to publish the DNS TXT record.
-Prepare the request first, show the TXT record to the operator, and only call
-`complete()` once the record has been published:
-
-```dart
-final pending = await letsEncrypt.prepareDnsPersistCertificateRequest(
-  const Domain(name: 'example.com', email: 'contact@example.com'),
-);
-
-print(pending.proof.txtRecordName);
-print(pending.proof.txtRecordValue);
-print(pending.proof.toBindString());
-
-// Wait for the operator to publish the TXT record...
-final ok = await pending.complete();
-```
-
-`complete()` validates the challenge, finalizes the order, fetches the
-certificate chain, and stores it through the configured `CertificatesHandler`.
-
-### CLI helper for dns-persist-01
-
-The package ships a CLI for the same manual `dns-persist-01` flow:
-
-```sh
-dart run shelf_letsencrypt_dns_persist \
-  --domain example.com \
-  --email contact@example.com \
-  --cert-dir ./certs
-```
-
-The CLI prepares the request, prints the TXT record details, prints a BIND-style
-record line, and waits for confirmation before it asks the ACME server to
-validate the challenge. It does not publish DNS records itself; publish the TXT
-record with your DNS provider before pressing ENTER.
-
-Useful options:
-
-- `--cert-dir <path>` chooses the certificate directory used by
-  `CertificatesHandlerIO`. Use the same directory your app will read from.
-- `--acme-dir <url>` targets a custom ACME directory, such as a local Pebble
-  server.
-- `--production` uses the Let's Encrypt production endpoint.
-- `--yes` skips the ENTER prompt. Use this only when automation has already
-  published the required TXT record.
 
 ## Renewals
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ it. It avoids serving transient HTTP challenge files and is designed for a
 stable delegated DNS TXT record tied to your ACME account.
 
 # Developing with shelf_letsencrypt
-Let's Encrypt provides a few challenges for your development environment.
-Read on for a few hints.
+ACME certificate authorities use challenges to prove that you control the
+domain before they issue a certificate. `shelf_letsencrypt` supports two
+challenge mechanisms, and the right choice changes what your development
+environment needs to expose.
 
 ## A word of caution
 Let's Encrypt rate-limits the issuing of production certificates.
@@ -49,35 +51,56 @@ final LetsEncrypt letsEncrypt = LetsEncrypt(certificatesHandler, production: fal
 ```
 
 
-## Permissions
-On Linux you need to be root (sudo) to open a port below 1024. If you try
-to start your server with the default ports (80, 443) you will fail.
+## Challenge mechanisms
 
+### http-01
 
-## NAT for your development environment
-To issue a certificate, Let's Encrypt needs to be able to connect to your
-web server on port 80.
-This will work fine in production (with the right firewall rules), but in
-a development environment can be a bit tricky.
+`http-01` is the default challenge type. The ACME server validates the request
+by fetching a token from:
 
-The above permission limitations add to the complication.
+```text
+http://<domain>/.well-known/acme-challenge/<token>
+```
 
-The easiest way to do this is (for dev):
-1. Start your server on ports 8080 and 8443 (or any pair above 1024).
-2. Set up two NAT rules on your router that forward ports to your dev machine:
-   80 -> 8080
-   443 -> 8443
+Development implications:
 
+- The domain's public DNS must resolve to the machine, router, or load balancer
+  that can reach your development server.
+- Port 80 must be reachable from the public internet. If your app listens on a
+  high port such as 8080, your router or firewall needs to forward public port
+  80 to that local port.
+- On Linux, binding directly to ports below 1024 usually requires root
+  privileges, `sudo`, or a capability such as `CAP_NET_BIND_SERVICE`.
+- This mode is convenient when your development machine is deliberately exposed
+  to the internet, but it is awkward behind carrier-grade NAT, restrictive
+  firewalls, or networks where inbound port forwarding is unavailable.
 
-## DNS for development
-For Let's Encrypt to issue a certificate, it must be able to resolve the domain
-name of the certificate that you are requesting.
+For local testing with `http-01`, I normally use a cheap test domain and point
+its A record at my development router. The router then forwards port 80 to the
+local server port used by the example app.
 
-To avoid tampering with your production DNS, I keep a cheap domain name that I
-use for testing.
-I then use Cloudflare's free DNS hosting service to host the domain name, which
-allows me to add the necessary A record pointing to my WFH router, where I've
-configured the above NAT.
+### dns-persist-01
+
+`dns-persist-01` proves control of the domain with a stable delegated DNS TXT
+record rather than an inbound HTTP request. Use it when your ACME CA supports
+the challenge and you can publish the required TXT record.
+
+Development implications:
+
+- Your development server does not need to be reachable from the public internet
+  for certificate issuance.
+- NAT and inbound port forwarding are not required for the ACME challenge.
+- You need control of the domain's DNS, or a delegated validation name, so the
+  TXT record can be published.
+- DNS publication can be automated with `dnsPersistChallengePublisher`, or you
+  can use `prepareDnsPersistCertificateRequest(...)` for a manual operator flow.
+- The issued certificate is still for the requested domain, so your application
+  DNS and routing still need to make sense for however you plan to serve the app
+  after the certificate is issued.
+
+This mode is the better fit for most development environments because the laptop
+or workstation can stay private. It also avoids coupling certificate issuance to
+home-router NAT, public Wi-Fi, or temporary firewall rules.
 
 ## Multi-Domain Support
 Starting with `shelf_letsencrypt: 2.0.0`, support for multiple domains on the
@@ -97,7 +120,18 @@ details, check out the source code on [GitHub][github_multi_domain_secure_server
 
 # Usage
 
-To use the `LetsEncrypt` class:
+Choose the challenge mechanism first, then wire `LetsEncrypt` for that flow.
+Use `production: false` while testing so certificate requests go to the staging
+ACME endpoint.
+
+### http-01 server flow (default)
+
+Use `http-01` when the ACME server can reach your app over public HTTP. This is
+the default `LetsEncrypt` mode and is the simplest production setup when port 80
+already routes to the server.
+
+The example below starts HTTP and HTTPS servers, serves ACME challenge responses
+from `/.well-known/acme-challenge/...`, and checks for certificate renewal:
 
 ```dart
 import 'dart:io';
@@ -134,11 +168,6 @@ void main(List<String> args) async {
     production: false, // If `true` uses Let's Encrypt production API.
     port: 80,
     securePort: 443,
-    // For automated dns-persist-01 use:
-    // challengeType: LetsEncryptChallengeType.dnsPersist,
-    // dnsPersistChallengePublisher: (domainName, proof) async {
-    //   print('Publish ${proof.txtRecordName} = ${proof.txtRecordValue}');
-    // },
   );
 
   var servers = await _startServer(letsEncrypt, domains);
@@ -215,6 +244,80 @@ Response _processRequest(Request request) =>
 
 ```
 
+### Automated dns-persist-01
+
+Use automated `dns-persist-01` when your ACME CA supports the challenge and your
+application can publish DNS TXT records through your DNS provider's API. In this
+mode, `shelf_letsencrypt` prepares the ACME challenge and calls your
+`dnsPersistChallengePublisher` callback with the TXT record that must exist
+before validation continues.
+
+```dart
+final letsEncrypt = LetsEncrypt(
+  certificatesHandler,
+  production: false,
+  challengeType: LetsEncryptChallengeType.dnsPersist,
+  dnsPersistChallengePublisher: (domainName, proof) async {
+    await publishTxtRecord(
+      proof.txtRecordName,
+      proof.txtRecordValue,
+    );
+  },
+);
+```
+
+`publishTxtRecord` is application code that you provide. It should create or
+update the TXT record through your DNS provider and return only when the record
+is ready for validation.
+
+### Manual dns-persist-01 API flow
+
+Use the manual API when a human operator needs to publish the DNS TXT record.
+Prepare the request first, show the TXT record to the operator, and only call
+`complete()` once the record has been published:
+
+```dart
+final pending = await letsEncrypt.prepareDnsPersistCertificateRequest(
+  const Domain(name: 'example.com', email: 'contact@example.com'),
+);
+
+print(pending.proof.txtRecordName);
+print(pending.proof.txtRecordValue);
+print(pending.proof.toBindString());
+
+// Wait for the operator to publish the TXT record...
+final ok = await pending.complete();
+```
+
+`complete()` validates the challenge, finalizes the order, fetches the
+certificate chain, and stores it through the configured `CertificatesHandler`.
+
+### CLI helper for dns-persist-01
+
+The package ships a CLI for the same manual `dns-persist-01` flow:
+
+```sh
+dart run shelf_letsencrypt_dns_persist \
+  --domain example.com \
+  --email contact@example.com \
+  --cert-dir ./certs
+```
+
+The CLI prepares the request, prints the TXT record details, prints a BIND-style
+record line, and waits for confirmation before it asks the ACME server to
+validate the challenge. It does not publish DNS records itself; publish the TXT
+record with your DNS provider before pressing ENTER.
+
+Useful options:
+
+- `--cert-dir <path>` chooses the certificate directory used by
+  `CertificatesHandlerIO`. Use the same directory your app will read from.
+- `--acme-dir <url>` targets a custom ACME directory, such as a local Pebble
+  server.
+- `--production` uses the Let's Encrypt production endpoint.
+- `--yes` skips the ENTER prompt. Use this only when automation has already
+  published the required TXT record.
+
 ## Renewals
 
 Each time you call `startServer`, it will check if any certificates need to
@@ -227,36 +330,6 @@ The example includes a renewal service that does a daily check to see if any
 certificates need renewing.
 If a cert needs to be renewed, it will renew it and then gracefully restart
 the server with the new certs.
-
-## Manual dns-persist-01 flow
-
-If you cannot publish DNS records automatically, prepare the request first,
-show the TXT record to an operator, and only continue once the record has been
-published:
-
-```dart
-final pending = await letsEncrypt.prepareDnsPersistCertificateRequest(
-  const Domain(name: 'example.com', email: 'contact@example.com'),
-);
-
-print(pending.proof.txtRecordName);
-print(pending.proof.txtRecordValue);
-
-// Wait for the operator to publish the TXT record...
-final ok = await pending.complete();
-```
-
-The package also ships a small CLI for this flow:
-
-```sh
-dart run shelf_letsencrypt_dns_persist \
-  --domain example.com \
-  --email contact@example.com \
-  --cert-dir ./certs
-```
-
-The CLI prints the TXT record, waits for confirmation, then validates and
-stores the issued certificate in the chosen certificate directory.
 
 ## Source
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 [letsencrypt]: https://letsencrypt.org/
 [letsencrypt_dns_persist_status]: https://letsencrypt.org/2026/02/18/dns-persist-01
 [letsencrypt_dns_persist_deployment]: https://community.letsencrypt.org/t/dns-persist-01-deployment-status-and-timeline/246468
+[letsencrypt_integration_guide]: https://letsencrypt.org/ca/docs/integration-guide/
+[letsencrypt_short_lifetimes]: https://letsencrypt.org/2025/12/02/from-90-to-45
 
 `dns-persist-01` is the recommended challenge type when your ACME CA supports
 it. It avoids serving transient HTTP challenge files, keeps your development
@@ -159,7 +161,19 @@ final letsEncrypt = LetsEncrypt(
 
 `publishTxtRecord` is application code that you provide. It should create or
 update the TXT record through your DNS provider and return only when the record
-is ready for validation.
+has been submitted to your DNS provider.
+
+Once the call to `publishTxtRecord` completes, `shelf_letsencrypt` will wait for
+DNS visibility before asking the ACME server to validate the challenge. It does
+this by calling the `dns-persist-01` challenge self-test supplied by
+`acme_client`; that self-test polls DNS for the required TXT record. If you set
+`selfTest: false`, this propagation check is skipped and your publisher must
+return only after the record is externally verifiable.
+
+If the persistent TXT record has already been published, you can omit
+`dnsPersistChallengePublisher` and leave `selfTest` enabled. In that case
+`shelf_letsencrypt` verifies the existing DNS record before asking the ACME
+server to validate the challenge.
 
 ### Manual dns-persist-01 API flow
 
@@ -182,6 +196,19 @@ final ok = await pending.complete();
 
 `complete()` validates the challenge, finalizes the order, fetches the
 certificate chain, and stores it through the configured `CertificatesHandler`.
+It is safe to call more than once on the same pending request: concurrent calls
+share the same in-flight completion, successful completion is cached, and a
+failed completion can be retried. Pass `timeout: ...` to `complete()` when you
+want the validation/finalization step to fail after a bounded wait and allow a
+later retry.
+
+For restart safety, use the same certificate directory when you rerun the manual
+flow. The account key and domain key are reused from that directory, so the
+`dns-persist-01` TXT record remains stable across process restarts. If a
+previous run already stored a valid certificate, `complete()` returns success
+without asking the ACME server to validate or finalize the order again. Pass
+`forceRequestCertificate: true` to `complete()` to request a new certificate
+even when a valid certificate is already stored.
 
 ### CLI helper for dns-persist-01
 
@@ -209,12 +236,17 @@ Useful options:
   `dns-persist-01` only when Let's Encrypt production supports the challenge.
 - `--yes` skips the ENTER prompt. Use this only when automation has already
   published the required TXT record.
+- `--force-request-certificate` requests a new certificate even if a valid
+  certificate is already stored in the certificate directory.
 
-### http-01 server flow (fallback/default)
+### http-01 server flow (default mode)
 
 Use `http-01` when the ACME server can reach your app over public HTTP. This is
 the default `LetsEncrypt` mode and is the simplest production setup when port 80
-already routes to the server.
+already routes to the server. `http-01` is not an automatic fallback from
+`dns-persist-01`; `challengeType: LetsEncryptChallengeType.dnsPersist` locks
+certificate requests to `dns-persist-01`, and issuance fails if the ACME CA does
+not offer that challenge.
 
 The example below starts HTTP and HTTPS servers, serves ACME challenge responses
 from `/.well-known/acme-challenge/...`, and checks for certificate renewal:
@@ -333,8 +365,34 @@ Response _processRequest(Request request) =>
 ## Renewals
 
 Each time you call `startServer`, it will check if any certificates need to
-be renewed in the next 5 days (or if they are expired) and renew the
-certificates.
+be renewed. By default, `shelf_letsencrypt` renews when the certificate has
+one third of its lifetime remaining, capped at 30 days. This means a 90 day
+certificate is renewed with about 30 days remaining, and a 45 day certificate is
+renewed with about 15 days remaining. You can tune this cap with
+`LetsEncrypt.minCertificateValidityTime`.
+
+This follows Let's Encrypt's backstop guidance to renew automatically when a
+certificate has one third of its lifetime left. ACME Renewal Information (ARI)
+is preferred where an ACME client supports it; `shelf_letsencrypt` does not
+currently use ARI. See Let's Encrypt's
+[integration guide][letsencrypt_integration_guide] and
+[shorter certificate lifetimes guidance][letsencrypt_short_lifetimes].
+
+Renewal uses the challenge type configured on the `LetsEncrypt` instance that
+performs the renewal. The existing certificate does not store which challenge
+type was used for the original request.
+
+For `dns-persist-01`, the TXT record should normally be
+published once, then reused across renewals while the same ACME account key is
+kept. If the record already exists, automated renewal can run without
+`dnsPersistChallengePublisher` as long as `selfTest` is enabled, because the
+library performs a DNS lookup before validation. If you provide a publisher, it
+should be idempotent: create the record when it is missing and otherwise leave
+the existing TXT record unchanged.
+
+The manual `prepareDnsPersistCertificateRequest(...)` flow is intended for
+operator-driven issuance and is not suitable for unattended renewal. It should
+not be needed for renewals if the TXT record still exists.
 
 This, however, isn't sufficient for any long-running service.
 

--- a/bin/shelf_letsencrypt_dns_persist.dart
+++ b/bin/shelf_letsencrypt_dns_persist.dart
@@ -1,0 +1,145 @@
+import 'dart:io';
+
+import 'package:shelf_letsencrypt/shelf_letsencrypt.dart';
+
+Future<void> main(List<String> args) async {
+  final options = _CliOptions.parse(args);
+  if (options == null) {
+    _printUsage(stderr);
+    exitCode = 64;
+    return;
+  }
+
+  final certificatesHandler = CertificatesHandlerIO(
+    Directory(options.certificatesDirectory),
+  );
+  final letsEncrypt = LetsEncrypt(
+    certificatesHandler,
+    challengeType: LetsEncryptChallengeType.dnsPersist,
+    production: options.production,
+    acmeDirectoryUrl: options.acmeDirectoryUrl,
+  );
+
+  final pending = await letsEncrypt.prepareDnsPersistCertificateRequest(
+    Domain(name: options.domain, email: options.email),
+  );
+
+  stdout.writeln('Publish this TXT record before continuing:\n');
+  stdout.writeln('Host : ${pending.proof.txtRecordName}');
+  stdout.writeln('Value: ${pending.proof.txtRecordValue}');
+  stdout.writeln('');
+  stdout.writeln('BIND: ${pending.proof.toBindString()}');
+  stdout.writeln('');
+
+  if (!options.autoContinue) {
+    stdout.writeln(
+      'Press ENTER after the TXT record is published and visible in DNS.',
+    );
+    stdin.readLineSync();
+  }
+
+  final ok = await pending.complete();
+  if (!ok) {
+    stderr.writeln('Certificate request did not complete successfully.');
+    exitCode = 1;
+    return;
+  }
+
+  stdout.writeln(
+    'Certificate issued and stored under ${options.certificatesDirectory}.',
+  );
+}
+
+class _CliOptions {
+  _CliOptions({
+    required this.domain,
+    required this.email,
+    required this.certificatesDirectory,
+    required this.production,
+    required this.acmeDirectoryUrl,
+    required this.autoContinue,
+  });
+
+  final String domain;
+  final String email;
+  final String certificatesDirectory;
+  final bool production;
+  final String? acmeDirectoryUrl;
+  final bool autoContinue;
+
+  static _CliOptions? parse(List<String> args) {
+    String? domain;
+    String? email;
+    String certificatesDirectory = 'certs';
+    String? acmeDirectoryUrl;
+    var production = false;
+    var autoContinue = false;
+
+    for (var i = 0; i < args.length; i++) {
+      final arg = args[i];
+      switch (arg) {
+        case '--domain':
+          domain = _nextValue(args, ++i, arg);
+          break;
+        case '--email':
+          email = _nextValue(args, ++i, arg);
+          break;
+        case '--cert-dir':
+          certificatesDirectory = _nextValue(args, ++i, arg) ?? 'certs';
+          break;
+        case '--acme-dir':
+          acmeDirectoryUrl = _nextValue(args, ++i, arg);
+          break;
+        case '--production':
+          production = true;
+          break;
+        case '--yes':
+          autoContinue = true;
+          break;
+        case '--help':
+        case '-h':
+          return null;
+        default:
+          stderr.writeln('Unknown argument: $arg');
+          return null;
+      }
+    }
+
+    if (domain == null || domain.isEmpty || email == null || email.isEmpty) {
+      return null;
+    }
+
+    return _CliOptions(
+      domain: domain,
+      email: email,
+      certificatesDirectory: certificatesDirectory,
+      production: production,
+      acmeDirectoryUrl: acmeDirectoryUrl,
+      autoContinue: autoContinue,
+    );
+  }
+
+  static String? _nextValue(List<String> args, int index, String option) {
+    if (index >= args.length) {
+      stderr.writeln('Missing value for $option');
+      return null;
+    }
+    return args[index];
+  }
+}
+
+void _printUsage(IOSink out) {
+  out.writeln(
+    'Usage: dart run shelf_letsencrypt_dns_persist --domain <fqdn> --email <contact>',
+  );
+  out.writeln('');
+  out.writeln('Options:');
+  out.writeln(
+    '  --cert-dir <path>   Directory used by CertificatesHandlerIO. Default: certs',
+  );
+  out.writeln('  --acme-dir <url>    Override the ACME directory URL.');
+  out.writeln(
+    '  --production        Use Let\'s Encrypt production instead of staging.',
+  );
+  out.writeln('  --yes               Do not wait for ENTER before continuing.');
+}

--- a/bin/shelf_letsencrypt_dns_persist.dart
+++ b/bin/shelf_letsencrypt_dns_persist.dart
@@ -38,7 +38,9 @@ Future<void> main(List<String> args) async {
     stdin.readLineSync();
   }
 
-  final ok = await pending.complete();
+  final ok = await pending.complete(
+    forceRequestCertificate: options.forceRequestCertificate,
+  );
   if (!ok) {
     stderr.writeln('Certificate request did not complete successfully.');
     exitCode = 1;
@@ -58,6 +60,7 @@ class _CliOptions {
     required this.production,
     required this.acmeDirectoryUrl,
     required this.autoContinue,
+    required this.forceRequestCertificate,
   });
 
   final String domain;
@@ -66,6 +69,7 @@ class _CliOptions {
   final bool production;
   final String? acmeDirectoryUrl;
   final bool autoContinue;
+  final bool forceRequestCertificate;
 
   static _CliOptions? parse(List<String> args) {
     String? domain;
@@ -74,6 +78,7 @@ class _CliOptions {
     String? acmeDirectoryUrl;
     var production = false;
     var autoContinue = false;
+    var forceRequestCertificate = false;
 
     for (var i = 0; i < args.length; i++) {
       final arg = args[i];
@@ -96,6 +101,9 @@ class _CliOptions {
         case '--yes':
           autoContinue = true;
           break;
+        case '--force-request-certificate':
+          forceRequestCertificate = true;
+          break;
         case '--help':
         case '-h':
           return null;
@@ -116,6 +124,7 @@ class _CliOptions {
       production: production,
       acmeDirectoryUrl: acmeDirectoryUrl,
       autoContinue: autoContinue,
+      forceRequestCertificate: forceRequestCertificate,
     );
   }
 
@@ -142,4 +151,7 @@ void _printUsage(IOSink out) {
     '  --production        Use Let\'s Encrypt production instead of staging.',
   );
   out.writeln('  --yes               Do not wait for ENTER before continuing.');
+  out.writeln(
+    '  --force-request-certificate  Request a certificate even if one is valid.',
+  );
 }

--- a/example/shelf_letsencrypt_example.dart
+++ b/example/shelf_letsencrypt_example.dart
@@ -32,6 +32,13 @@ void main(List<String> args) async {
     production: false, // If `true` uses Let's Encrypt production API.
     port: 80,
     securePort: 443,
+    // For dns-persist-01 use:
+    // challengeType: LetsEncryptChallengeType.dnsPersist,
+    // dnsPersistChallengePublisher: (domainName, proof) async {
+    //   print('Publish ${proof.txtRecordName} = ${proof.txtRecordValue}');
+    // },
+    // For a manual dns-persist-01 flow, call:
+    // await letsEncrypt.prepareDnsPersistCertificateRequest(domain);
   );
 
   var servers = await _startServer(letsEncrypt, domains);

--- a/lib/shelf_letsencrypt.dart
+++ b/lib/shelf_letsencrypt.dart
@@ -8,5 +8,6 @@ export 'src/domain.dart';
 export 'src/domain_certificate_file_path.dart';
 export 'src/letsencrypt.dart';
 export 'src/logging.dart' show Logging;
+export 'src/pending_dns_persist_request.dart';
 export 'src/pem_key_pair.dart';
 export 'src/security_context_builder.dart';

--- a/lib/src/certificates_handler_io.dart
+++ b/lib/src/certificates_handler_io.dart
@@ -291,7 +291,11 @@ class CertificatesHandlerIO extends CertificatesHandler {
     };
 
     final csr = X509Utils.generateRsaCsrPem(
-        attributes, domainKeyPair.privateKey, domainKeyPair.publicKey);
+      attributes,
+      domainKeyPair.privateKey,
+      domainKeyPair.publicKey,
+      san: [cn],
+    );
 
     return csr;
   }

--- a/lib/src/letsencrypt.dart
+++ b/lib/src/letsencrypt.dart
@@ -11,6 +11,24 @@ import 'certs_handler.dart';
 import 'check_certificate_status.dart';
 import 'domain.dart';
 import 'logging.dart';
+import 'pending_dns_persist_request.dart';
+
+/// The ACME challenge workflow used by [LetsEncrypt].
+enum LetsEncryptChallengeType {
+  /// Serve an `http-01` response from `/.well-known/acme-challenge/...`.
+  http,
+
+  /// Publish a persistent `dns-persist-01` TXT record.
+  dnsPersist,
+}
+
+/// Publishes the TXT record required for a `dns-persist-01` challenge.
+///
+/// `shelf_letsencrypt` can satisfy `http-01` itself because it controls the
+/// HTTP server. DNS publication is environment-specific, so callers must wire
+/// this callback to their DNS provider or automation.
+typedef DnsPersistChallengePublisher = FutureOr<void> Function(
+    String domainName, DnsPersistChallengeProof proof);
 
 /// Let's Encrypt certificate tool.
 class LetsEncrypt {
@@ -18,6 +36,10 @@ class LetsEncrypt {
   final int securePort;
   final String bindingAddress;
   final bool selfTest;
+  final String? acmeDirectoryUrl;
+  final LetsEncryptChallengeType challengeType;
+  final DnsPersistChallengePublisher? dnsPersistChallengePublisher;
+  final AcmeConnection? acmeConnection;
 
   LetsEncrypt(this.certificatesHandler,
       {this.port = 80,
@@ -25,6 +47,10 @@ class LetsEncrypt {
       this.bindingAddress = '0.0.0.0',
       this.production = false,
       this.selfTest = true,
+      this.acmeDirectoryUrl,
+      this.challengeType = LetsEncryptChallengeType.http,
+      this.dnsPersistChallengePublisher,
+      this.acmeConnection,
       Logging? log})
       : logger = Logger(log);
 
@@ -53,9 +79,11 @@ class LetsEncrypt {
   final bool production;
 
   /// Returns the Let's Encrypt API base URL in use.
-  String get apiBaseURL => production
-      ? 'https://acme-v02.api.letsencrypt.org'
-      : 'https://acme-staging-v02.api.letsencrypt.org';
+  String get apiBaseURL =>
+      acmeDirectoryUrl ??
+      (production
+          ? 'https://acme-v02.api.letsencrypt.org'
+          : 'https://acme-staging-v02.api.letsencrypt.org');
 
   final Map<String, String> _challengesTokens = <String, String>{};
 
@@ -64,7 +92,7 @@ class LetsEncrypt {
 
   static final RegExp _regexpContactMethodPrefix = RegExp(r'^\w+:');
 
-  /// Performs an `ACME` challenge. Default to `HTTP-1`.
+  /// Performs an `ACME` challenge using the configured [challengeType].
   /// - [cn] is the domain to request a certificate.
   /// - [contacts] is the list of domain contacts, usually emails.
   /// - [accountPrivateKeyPem] is the account private key in PEM format.
@@ -88,161 +116,273 @@ class LetsEncrypt {
     logger.info(
         'apiBaseURL: $apiBaseURL ; cn: $cn ; contacts: $contactsWithMethod');
 
-    final client = AcmeClient(
-      apiBaseURL,
-      accountPrivateKeyPem,
-      accountPublicKeyPem,
-      true,
-      contactsWithMethod,
+    final accountCredentials = AcmeAccountCredentials(
+      privateKeyPem: accountPrivateKeyPem,
+      publicKeyPem: accountPublicKeyPem,
+      acceptTerms: true,
+      contacts: contactsWithMethod,
+    );
+    final certificateCredentials = CertificateCredentials(
+      privateKeyPem: '',
+      publicKeyPem: '',
+      csrPem: domainCSR,
+      identifiers: [DomainIdentifier(cn)],
+    );
+    try {
+      final account = await _fetchOrCreateAccount(accountCredentials, cn);
+      final identifier = DomainIdentifier(cn);
+
+      switch (challengeType) {
+        case LetsEncryptChallengeType.http:
+          return _doHttpChallenge(
+            account: account,
+            cn: cn,
+            identifier: identifier,
+            certificateCredentials: certificateCredentials,
+          );
+        case LetsEncryptChallengeType.dnsPersist:
+          return _doDnsPersistChallenge(
+            account: account,
+            cn: cn,
+            identifier: identifier,
+            certificateCredentials: certificateCredentials,
+          );
+      }
+    } catch (e, s) {
+      logger.error(e, s);
+      rethrow;
+    } finally {
+      _challengesTokens.remove(cn);
+    }
+  }
+
+  Future<Account> _fetchOrCreateAccount(
+    AcmeAccountCredentials credentials,
+    String cn,
+  ) async {
+    try {
+      return await Account.fetch(credentials, connection: _connection);
+    } catch (e, s) {
+      logger.warning('Failed to fetch ACME account, trying create', e, s);
+    }
+
+    try {
+      return await Account.create(credentials, connection: _connection);
+    } catch (e, s) {
+      logger.error('Failed to create ACME account for domain: $cn', e, s);
+      rethrow;
+    }
+  }
+
+  Future<List<String>> _doHttpChallenge({
+    required Account account,
+    required String cn,
+    required DomainIdentifier identifier,
+    required CertificateCredentials certificateCredentials,
+  }) async {
+    final order = await account.createOrderForHttp(identifiers: [identifier]);
+    final authorization = await order.getAuthorization(identifier);
+    final challenge = authorization.getChallenge();
+    final proof = challenge.buildProof();
+
+    _challengesTokens[cn] = proof.wellKnownChallengeFileContent;
+
+    logger.info(
+      'Serving http-01 challenge for $cn at ${proof.pathToWellKnownChallenge}',
     );
 
-    await _initializeClient(client, cn);
+    return _validateFinalizeAndFetch(
+      cn: cn,
+      challengeSelfTest: () => challenge.selfTest(),
+      challengeValidate: () => challenge.validate(),
+      orderIsReady: () => order.isReady(),
+      orderFinalize: () => order.finalize(certificateCredentials),
+      orderGetCertificates: () => order.getCertificates(),
+    );
+  }
 
-    final order = Order(identifiers: [Identifiers(type: 'dns', value: cn)]);
-    logger.info('Order for $cn: ${order.toJson()}');
-
-    final newOrder = await client.order(order);
-
-    logger.info('Fetching authorization data for order...');
-
-    final auth = await client.getAuthorization(newOrder!);
-    if (auth == null || auth.isEmpty) {
-      throw StateError("Can't get Authorization");
+  Future<List<String>> _doDnsPersistChallenge({
+    required Account account,
+    required String cn,
+    required DomainIdentifier identifier,
+    required CertificateCredentials certificateCredentials,
+  }) async {
+    final publish = dnsPersistChallengePublisher;
+    if (publish == null) {
+      throw StateError(
+        'LetsEncrypt configured for dns-persist-01 but no dnsPersistChallengePublisher was provided',
+      );
     }
 
-    final mainAuth = auth.first;
-    final challengeData = mainAuth.getHttpDcvData();
+    final order = await account.createOrderForDnsPersist(
+      identifiers: [identifier],
+    );
+    final authorization = await order.getAuthorization(identifier);
+    final challenge = authorization.getChallenge();
+    final proof = challenge.buildProof();
 
-    _challengesTokens[cn] = challengeData.fileContent;
+    logger.info(
+      'Publishing dns-persist-01 challenge for $cn: ${proof.toBindString()}',
+    );
+    await publish(cn, proof);
 
-    logger.info('Self test challenge... ${challengeData.toJson()}');
+    return _validateFinalizeAndFetch(
+      cn: cn,
+      challengeSelfTest: () => challenge.selfTest(),
+      challengeValidate: () => challenge.validate(),
+      orderIsReady: () => order.isReady(),
+      orderFinalize: () => order.finalize(certificateCredentials),
+      orderGetCertificates: () => order.getCertificates(),
+    );
+  }
 
+  /// Prepares a manual `dns-persist-01` flow for [domain].
+  ///
+  /// This is intended for environments where a human operator must publish the
+  /// TXT record before validation continues. The returned [PendingDnsPersistRequest]
+  /// contains the record to publish and a [PendingDnsPersistRequest.complete]
+  /// callback that should be invoked only after the record is visible in DNS.
+  Future<PendingDnsPersistRequest> prepareDnsPersistCertificateRequest(
+    Domain domain,
+  ) async {
+    final accountKeyPair = await certificatesHandler.ensureAccountPEMKeyPair();
+    await certificatesHandler.ensureDomainPEMKeyPair(domain.name);
+
+    final csr =
+        await certificatesHandler.generateCSR(domain.name, domain.email);
+    if (csr == null) {
+      throw StateError("Can't generate CSR for domain: $domain");
+    }
+
+    final accountCredentials = AcmeAccountCredentials(
+      privateKeyPem: accountKeyPair.privateKeyPEM,
+      publicKeyPem: accountKeyPair.publicKeyPEM,
+      acceptTerms: true,
+      contacts: ['mailto:${domain.email}'],
+    );
+    final certificateCredentials = CertificateCredentials(
+      privateKeyPem: '',
+      publicKeyPem: '',
+      csrPem: csr,
+      identifiers: [DomainIdentifier(domain.name)],
+    );
+    final account =
+        await _fetchOrCreateAccount(accountCredentials, domain.name);
+    final identifier = DomainIdentifier(domain.name);
+    final order = await account.createOrderForDnsPersist(
+      identifiers: [identifier],
+    );
+    final authorization = await order.getAuthorization(identifier);
+    final challenge = authorization.getChallenge();
+    final proof = challenge.buildProof();
+
+    logger.info(
+      'Prepared dns-persist-01 challenge for ${domain.name}: ${proof.toBindString()}',
+    );
+
+    return PendingDnsPersistRequest.internal(
+      domainName: domain.name,
+      proof: proof,
+      complete: () async {
+        final certs = await _validateFinalizeAndFetch(
+          cn: domain.name,
+          challengeSelfTest: () => challenge.selfTest(),
+          challengeValidate: () => challenge.validate(),
+          orderIsReady: () => order.isReady(),
+          orderFinalize: () => order.finalize(certificateCredentials),
+          orderGetCertificates: () => order.getCertificates(),
+        );
+
+        return certificatesHandler.saveSignedCertificateChain(
+          domain.name,
+          certs,
+        );
+      },
+    );
+  }
+
+  Future<List<String>> _validateFinalizeAndFetch({
+    required String cn,
+    required Future<bool> Function() challengeSelfTest,
+    required Future<bool> Function() challengeValidate,
+    required Future<bool> Function() orderIsReady,
+    required Future<void> Function() orderFinalize,
+    required Future<List<String>> Function() orderGetCertificates,
+  }) async {
     if (selfTest) {
-      final selfTestOK = await _selfChallengeTest(client, challengeData);
+      final selfTestOK = await challengeSelfTest();
       if (!selfTestOK) {
-        throw StateError('Self HTTP test not OK!');
+        throw StateError('Challenge self-test not OK for $cn');
       }
     }
-    final challenge =
-        mainAuth.challenges!.firstWhere((e) => e.type == VALIDATION_HTTP);
 
-    logger.info('Validating challenge: ${challenge.toJson()}');
-    final valid = await client.validate(challenge);
-
+    final valid = await challengeValidate();
     if (!valid) {
-      // if you trace through client.validate it returns a response
-      // object and you can find the actual problem in
-      // response!.data['challenges'][0]['error']['detail']
       throw StateError('Challenge not valid - check your firewall and DNS!');
     }
 
     logger.info('Authorization successful!');
 
-    await Future.delayed(const Duration(seconds: 1), () {});
-
-    final ready = await client.isReady(newOrder);
+    final ready = await _waitUntilOrderReady(orderIsReady);
     if (!ready) {
       throw StateError('Order not ready!');
     }
 
     logger.info('Finalizing order...');
-    final persistent = await client.finalizeOrder(newOrder, domainCSR);
-
-    if (persistent == null) {
-      throw StateError('Error finalizing order!');
-    }
+    await orderFinalize();
 
     logger.info('Getting certificates...');
-    final certs = await client.getCertificate(persistent);
-
-    _challengesTokens.remove(cn);
-
-    if (certs == null || certs.isEmpty) {
+    final certs = await orderGetCertificates();
+    if (certs.isEmpty) {
       throw StateError('Error getting certificates!');
     }
 
     logger.info('Certificates:\n>> ${certs.join('\n>> ')}');
-
     return certs;
   }
 
-  Future<bool> _initializeClient(AcmeClient client, String cn) async {
-    try {
-      await client.init();
-      return true;
-    } catch (e, s) {
-      logger.error(e, s);
-      await _initializeClientFallback(client, cn);
-      return true;
-    }
-  }
-
-  Future<void> _initializeClientFallback(AcmeClient client, String cn) async {
-    logger.info('Trying initialization fallback...');
-
-    Account? account;
-    try {
-      account = await client.getAccount(createIfnotExists: false);
-    } catch (e, s) {
-      logger.error(e, s);
-    }
-
-    try {
-      if (account == null) {
-        logger.info('Creating account...');
-        account = await client.createAccount();
+  Future<bool> _waitUntilOrderReady(
+    Future<bool> Function() orderIsReady, {
+    int maxAttempts = 5,
+  }) async {
+    for (var attempt = 0; attempt < maxAttempts; attempt++) {
+      if (await orderIsReady()) {
+        return true;
       }
-    } catch (e, s) {
-      logger.error(e, s);
-    }
-
-    if (account == null) {
-      throw StateError("Can't initialize account for domain: $cn");
-    }
-  }
-
-  Future<bool> _selfChallengeTest(
-      AcmeClient client, HttpDcvData challengeData) async {
-    var url = challengeData.fileName;
-    if (!url.startsWith('http:') && !url.startsWith('https:')) {
-      final idx = url.indexOf(':/');
-      if (idx >= 0) {
-        final schema = url.substring(0, idx);
-        var rest = url.substring(idx);
-        rest = rest.replaceFirst(RegExp('^/+'), '');
-        url = '$schema://${rest.replaceAll('//', '/')}';
-      } else {
-        var rest = url.replaceFirst(RegExp('^/+'), '');
-        rest = rest.replaceFirst(RegExp('/'), ':$port/');
-        rest = rest.replaceAll('//', '/');
-        url = 'http://$rest';
+      if (attempt + 1 < maxAttempts) {
+        await Future.delayed(const Duration(seconds: 1), () {});
       }
     }
+    return false;
+  }
 
-    logger.info('Self test URL: $url');
+  AcmeConnection get _connection =>
+      acmeConnection ??
+      AcmeConnection(
+        baseUrl: acmeDirectoryUrl ??
+            (production
+                ? AcmeConnection.letsEncryptDirectoryUrl
+                : AcmeConnection.letsEncryptStagingDirectoryUrl),
+        logger: _logAcme,
+      );
 
-    String? content;
-    try {
-      content = await getURL(Uri.parse(url));
-    } catch (e, s) {
-      logger.error('Self test request error for URL: $url', e, s);
-      return false;
+  void _logAcme(
+    AcmeLogLevel level,
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    switch (level) {
+      case AcmeLogLevel.debug:
+        logger.info(message, stackTrace);
+        break;
+      case AcmeLogLevel.warning:
+        logger.warning(message, error, stackTrace);
+        break;
+      case AcmeLogLevel.error:
+        logger.error(message, error, stackTrace);
+        break;
     }
-
-    if (content == null || content.isEmpty) {
-      logger.info('Self test: EMPTY');
-      return false;
-    }
-
-    final match = content.trim() == challengeData.fileContent;
-
-    if (match) {
-      logger.info('Self test: OK');
-    } else {
-      logger.warning('Self test: ERROR <$content>');
-    }
-
-    return match;
   }
 
   /// A helper method to process a self check [Request].
@@ -528,6 +668,15 @@ class LetsEncrypt {
   ///
   /// Calls [doACMEChallenge].
   Future<bool> requestCertificate(Domain domain) async {
+    if (challengeType == LetsEncryptChallengeType.dnsPersist &&
+        dnsPersistChallengePublisher == null) {
+      throw StateError(
+        'LetsEncrypt configured for dns-persist-01 without a publisher. '
+        'Use prepareDnsPersistCertificateRequest(domain) for a manual flow '
+        'or provide dnsPersistChallengePublisher for automated publication.',
+      );
+    }
+
     final accountKeyPair = await certificatesHandler.ensureAccountPEMKeyPair();
 
     await certificatesHandler.ensureDomainPEMKeyPair(domain.name);

--- a/lib/src/letsencrypt.dart
+++ b/lib/src/letsencrypt.dart
@@ -20,12 +20,19 @@ class LetsEncrypt {
       this.securePort = 443,
       this.bindingAddress = '0.0.0.0',
       this.production = false,
+      this.selfTest = true,
       Logging? log})
       : logger = Logger(log);
 
   final int port;
   final int securePort;
   final String bindingAddress;
+
+  /// If try we make a connection back to ourseleves
+  /// to ensure that port 80 is open.
+  /// This doesn't work so well in a containerised environment
+  /// so we provide the option to disable it.
+  final bool selfTest;
 
   Logger logger;
 
@@ -116,11 +123,12 @@ class LetsEncrypt {
 
     logger.info('Self test challenge... ${challengeData.toJson()}');
 
-    final selfTestOK = await _selfChallengeTest(client, challengeData);
-    if (!selfTestOK) {
-      throw StateError('Self HTTP test not OK!');
+    if (selfTest) {
+      final selfTestOK = await _selfChallengeTest(client, challengeData);
+      if (!selfTestOK) {
+        throw StateError('Self HTTP test not OK!');
+      }
     }
-
     final challenge =
         mainAuth.challenges!.firstWhere((e) => e.type == VALIDATION_HTTP);
 

--- a/lib/src/letsencrypt.dart
+++ b/lib/src/letsencrypt.dart
@@ -208,12 +208,6 @@ class LetsEncrypt {
     required CertificateCredentials certificateCredentials,
   }) async {
     final publish = dnsPersistChallengePublisher;
-    if (publish == null) {
-      throw StateError(
-        'LetsEncrypt configured for dns-persist-01 but no dnsPersistChallengePublisher was provided',
-      );
-    }
-
     final order = await account.createOrderForDnsPersist(
       identifiers: [identifier],
     );
@@ -221,10 +215,17 @@ class LetsEncrypt {
     final challenge = authorization.getChallenge();
     final proof = challenge.buildProof();
 
-    logger.info(
-      'Publishing dns-persist-01 challenge for $cn: ${proof.toBindString()}',
-    );
-    await publish(cn, proof);
+    if (publish == null) {
+      logger.info(
+        'No dns-persist-01 publisher configured for $cn; '
+        'validating existing DNS record: ${proof.toBindString()}',
+      );
+    } else {
+      logger.info(
+        'Publishing dns-persist-01 challenge for $cn: ${proof.toBindString()}',
+      );
+      await publish(cn, proof);
+    }
 
     return _validateFinalizeAndFetch(
       cn: cn,
@@ -283,7 +284,15 @@ class LetsEncrypt {
     return PendingDnsPersistRequest.internal(
       domainName: domain.name,
       proof: proof,
-      complete: () async {
+      complete: ({bool forceRequestCertificate = false}) async {
+        if (!forceRequestCertificate &&
+            certificatesHandler.isHandledDomainCertificate(domain.name)) {
+          logger.info(
+            'Certificate for ${domain.name} is already stored and valid.',
+          );
+          return true;
+        }
+
         final certs = await _validateFinalizeAndFetch(
           cn: domain.name,
           challengeSelfTest: () => challenge.selfTest(),
@@ -669,11 +678,13 @@ class LetsEncrypt {
   /// Calls [doACMEChallenge].
   Future<bool> requestCertificate(Domain domain) async {
     if (challengeType == LetsEncryptChallengeType.dnsPersist &&
-        dnsPersistChallengePublisher == null) {
+        dnsPersistChallengePublisher == null &&
+        !selfTest) {
       throw StateError(
-        'LetsEncrypt configured for dns-persist-01 without a publisher. '
-        'Use prepareDnsPersistCertificateRequest(domain) for a manual flow '
-        'or provide dnsPersistChallengePublisher for automated publication.',
+        'LetsEncrypt configured for dns-persist-01 with no publisher and '
+        'selfTest disabled. Provide dnsPersistChallengePublisher, enable '
+        'selfTest so the existing TXT record can be verified, or use '
+        'prepareDnsPersistCertificateRequest(domain) for a manual flow.',
       );
     }
 
@@ -696,10 +707,14 @@ class LetsEncrypt {
     return ok;
   }
 
-  /// The minimal accepted HTTPS certificate validity time
-  /// when checking the current certificate validity. Default: 5 days
+  /// The maximum renewal buffer when checking the current certificate validity.
+  ///
+  /// The effective buffer is the smaller of this value and one third of the
+  /// certificate lifetime. With the default 30 day cap, a 90 day certificate is
+  /// renewed with 30 days remaining and a 45 day certificate is renewed with 15
+  /// days remaining.
   /// - See [isDomainHttpsOK].
-  Duration minCertificateValidityTime = const Duration(days: 5);
+  Duration minCertificateValidityTime = const Duration(days: 30);
 
   /// Returns true if [domain] HTTPS is OK.
   Future<bool> isDomainHttpsOK(Domain domain,
@@ -770,11 +785,16 @@ class LetsEncrypt {
         return null;
       }
 
-      if (minCertificateValidityTime != null &&
-          timeLeftInValidity < minCertificateValidityTime) {
-        logger.warning(
-            'URL `${url.scheme}://${url.host}` certificate short validity period> timeLeftInValidity: ${timeLeftInValidity.inHours} h ; minCertificateValidityTime: ${minCertificateValidityTime.inHours} h ; endValidity: $endValidity ; now: $now');
-        return null;
+      if (minCertificateValidityTime != null) {
+        final effectiveMinValidityTime = _effectiveMinCertificateValidityTime(
+          certificate,
+          minCertificateValidityTime,
+        );
+        if (timeLeftInValidity < effectiveMinValidityTime) {
+          logger.warning(
+              'URL `${url.scheme}://${url.host}` certificate short validity period> timeLeftInValidity: ${timeLeftInValidity.inHours} h ; minCertificateValidityTime: ${effectiveMinValidityTime.inHours} h ; endValidity: $endValidity ; now: $now');
+          return null;
+        }
       }
     }
 
@@ -782,6 +802,28 @@ class LetsEncrypt {
     final body = data.join();
 
     return body;
+  }
+
+  Duration _effectiveMinCertificateValidityTime(
+    X509Certificate certificate,
+    Duration maxRenewalBuffer,
+  ) {
+    final lifetime = certificate.endValidity.difference(
+      certificate.startValidity,
+    );
+    if (lifetime <= Duration.zero) {
+      return maxRenewalBuffer;
+    }
+
+    final oneThirdLifetime = Duration(
+      microseconds: lifetime.inMicroseconds ~/ 3,
+    );
+    if (oneThirdLifetime <= Duration.zero ||
+        oneThirdLifetime > maxRenewalBuffer) {
+      return maxRenewalBuffer;
+    }
+
+    return oneThirdLifetime;
   }
 
   /// Handles a bad certificate triggered by [HttpClient].

--- a/lib/src/pending_dns_persist_request.dart
+++ b/lib/src/pending_dns_persist_request.dart
@@ -1,0 +1,30 @@
+import 'package:acme_client/acme_client.dart';
+
+import 'letsencrypt.dart';
+
+/// A prepared `dns-persist-01` request waiting for the caller to publish the
+/// TXT record before certificate issuance can continue.
+///
+/// Typical flow:
+///
+/// 1. Call [LetsEncrypt.prepareDnsPersistCertificateRequest].
+/// 2. Show [proof] to an operator or publish it through your DNS automation.
+/// 3. Once the TXT record is live, call [complete].
+class PendingDnsPersistRequest {
+  PendingDnsPersistRequest.internal({
+    required this.domainName,
+    required this.proof,
+    required this.complete,
+  });
+
+  /// The domain being validated.
+  final String domainName;
+
+  /// The persistent TXT record the user must publish.
+  final DnsPersistChallengeProof proof;
+
+  /// Completes validation, finalizes the order, and stores the certificate.
+  ///
+  /// Call this only after the TXT record from [proof] has been published.
+  final Future<bool> Function() complete;
+}

--- a/lib/src/pending_dns_persist_request.dart
+++ b/lib/src/pending_dns_persist_request.dart
@@ -14,8 +14,8 @@ class PendingDnsPersistRequest {
   PendingDnsPersistRequest.internal({
     required this.domainName,
     required this.proof,
-    required this.complete,
-  });
+    required Future<bool> Function({bool forceRequestCertificate}) complete,
+  }) : _complete = complete;
 
   /// The domain being validated.
   final String domainName;
@@ -23,8 +23,51 @@ class PendingDnsPersistRequest {
   /// The persistent TXT record the user must publish.
   final DnsPersistChallengeProof proof;
 
+  final Future<bool> Function({bool forceRequestCertificate}) _complete;
+
+  Future<bool>? _completion;
+
   /// Completes validation, finalizes the order, and stores the certificate.
   ///
   /// Call this only after the TXT record from [proof] has been published.
-  final Future<bool> Function() complete;
+  ///
+  /// This method is idempotent for a prepared request unless
+  /// [forceRequestCertificate] is `true`. Concurrent calls share the same
+  /// in-flight completion, and calls after a successful completion return the
+  /// same result. If completion fails or [timeout] expires, a later call retries
+  /// the validation/finalization step.
+  Future<bool> complete({
+    bool forceRequestCertificate = false,
+    Duration? timeout,
+  }) {
+    if (forceRequestCertificate) {
+      _completion = null;
+      return _completion = _completeOnce(
+        forceRequestCertificate: true,
+        timeout: timeout,
+      );
+    }
+
+    final completion = _completion;
+    if (completion != null) {
+      return completion;
+    }
+
+    return _completion = _completeOnce(timeout: timeout);
+  }
+
+  Future<bool> _completeOnce({
+    bool forceRequestCertificate = false,
+    Duration? timeout,
+  }) async {
+    try {
+      final completion = _complete(
+        forceRequestCertificate: forceRequestCertificate,
+      );
+      return await (timeout == null ? completion : completion.timeout(timeout));
+    } catch (_) {
+      _completion = null;
+      rethrow;
+    }
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: shelf_letsencrypt
 version: 2.2.0
 homepage: https://github.com/gmpassos/shelf_letsencrypt
-publish_to: https://onepub.dev/api/jbbxpsdavu/
+publish_to: none
 description: Let's Encrypt support for the shelf package (free and automatic HTTPS certificate support).
 
 executables:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,12 +7,12 @@ description: Let's Encrypt support for the shelf package (free and automatic HTT
 executables:
   shelf_letsencrypt_dns_persist:
 
-
 environment:
-  sdk: '>=3.5.0 <4.0.0'
+  sdk: ">=3.5.0 <4.0.0"
 
 dependencies:
-  acme_client: ^2.0.0
+  acme_client: #^2.0.0
+    git: https://github.com/onepub-dev/Dart-Acme-Client.git
   basic_utils: ^5.8.2
   collection: ^1.19.0
   multi_domain_secure_server: ^1.0.16

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,12 @@
 name: shelf_letsencrypt
-version: 2.0.0
+version: 2.0.3
 homepage: https://github.com/gmpassos/shelf_letsencrypt
+publish_to: https://onepub.dev/api/jbbxpsdavu/
 description: Let's Encrypt support for the shelf package (free and automatic HTTPS certificate support).
 environment: 
   sdk: '>=3.0.0 <4.0.0'
 dependencies: 
-  acme_client: ^1.2.0
+  acme_client: ^1.3.0
   basic_utils: ^5.6.1
   collection: ^1.18.0
   coverage: ^1.6.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,18 @@
 name: shelf_letsencrypt
-version: 2.0.3
+version: 2.2.0
 homepage: https://github.com/gmpassos/shelf_letsencrypt
 publish_to: https://onepub.dev/api/jbbxpsdavu/
 description: Let's Encrypt support for the shelf package (free and automatic HTTPS certificate support).
+
+executables:
+  shelf_letsencrypt_dns_persist:
 
 
 environment:
   sdk: '>=3.5.0 <4.0.0'
 
 dependencies:
-  acme_client: ^1.3.0
+  acme_client: ^2.0.0
   basic_utils: ^5.8.2
   collection: ^1.19.0
   multi_domain_secure_server: ^1.0.16
@@ -17,10 +20,11 @@ dependencies:
   shelf: ^1.4.2
 
 dev_dependencies:
-  cron: ^0.5.1
+  cron: ^0.6.2
   dependency_validator: ^5.0.3
+  dio: ^5.0.0
   coverage: ^1.15.0
-  lints: ^5.1.1
+  lints: ^6.1.0
   test: ^1.28.0
 
 #dependency_overrides:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,8 +11,7 @@ environment:
   sdk: ">=3.5.0 <4.0.0"
 
 dependencies:
-  acme_client: #^2.0.0
-    git: https://github.com/onepub-dev/Dart-Acme-Client.git
+  acme_client: ^2.0.0
   basic_utils: ^5.8.2
   collection: ^1.19.0
   multi_domain_secure_server: ^1.0.16

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,6 @@
 name: shelf_letsencrypt
 version: 2.2.0
 homepage: https://github.com/gmpassos/shelf_letsencrypt
-publish_to: none
 description: Let's Encrypt support for the shelf package (free and automatic HTTPS certificate support).
 
 executables:

--- a/test/dns_persist_pebble_test.dart
+++ b/test/dns_persist_pebble_test.dart
@@ -1,0 +1,112 @@
+// Integration-style test setup keeps long environment names and URLs intact.
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:acme_client/acme_client.dart' show AcmeConnection;
+import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
+import 'package:path/path.dart' as pack_path;
+import 'package:shelf_letsencrypt/shelf_letsencrypt.dart';
+import 'package:test/test.dart';
+
+const _pebbleEnabledEnv = 'ACME_PEBBLE_ENABLE_TESTS';
+const _pebbleBaseUrlEnv = 'ACME_PEBBLE_BASE_URL';
+const _pebbleManagementUrlEnv = 'ACME_PEBBLE_MANAGEMENT_URL';
+const _pebbleIdentifierEnv = 'ACME_PEBBLE_IDENTIFIER';
+const _pebbleTrustedRootEnv = 'ACME_PEBBLE_TRUSTED_ROOT';
+
+void main() {
+  final enabled = Platform.environment[_pebbleEnabledEnv] == 'true';
+  final baseUrl =
+      Platform.environment[_pebbleBaseUrlEnv] ?? 'https://localhost:14000/dir';
+  final managementUrl =
+      Platform.environment[_pebbleManagementUrlEnv] ?? 'http://localhost:8055';
+  final identifier =
+      Platform.environment[_pebbleIdentifierEnv] ?? 'example.com';
+  final trustedRootPath = Platform.environment[_pebbleTrustedRootEnv];
+
+  late Directory tmpDir;
+
+  setUp(() {
+    tmpDir = Directory.systemTemp.createTempSync(
+      'shelf-letsencrypt-pebble-',
+    );
+  });
+
+  tearDown(() {
+    if (tmpDir.existsSync()) {
+      tmpDir.deleteSync(recursive: true);
+    }
+  });
+
+  test(
+    'Pebble dns-persist-01 end-to-end',
+    () async {
+      final certificatesHandler = CertificatesHandlerIO(
+        Directory(pack_path.join(tmpDir.path, 'certs')),
+      );
+      final letsEncrypt = LetsEncrypt(
+        certificatesHandler,
+        selfTest: false,
+        challengeType: LetsEncryptChallengeType.dnsPersist,
+        acmeDirectoryUrl: baseUrl,
+        acmeConnection: AcmeConnection(
+          baseUrl: baseUrl,
+          dio: _buildPebbleDio(trustedRootPath),
+        ),
+        dnsPersistChallengePublisher: (domainName, proof) async {
+          expect(domainName, identifier);
+          await _publishTxtRecord(
+            managementUrl,
+            proof.txtRecordName,
+            proof.txtRecordValue,
+          );
+        },
+      );
+
+      final ok = await letsEncrypt.requestCertificate(
+        Domain(name: identifier, email: 'contact@$identifier'),
+      );
+
+      expect(ok, isTrue);
+      final fullChainFile = certificatesHandler.fileDomainFullChainPEM(
+        identifier,
+      );
+      expect(fullChainFile.existsSync(), isTrue);
+      expect(fullChainFile.readAsStringSync(), contains('BEGIN CERTIFICATE'));
+    },
+    skip: enabled
+        ? false
+        : 'Set $_pebbleEnabledEnv=true to run against the local Pebble harness.',
+  );
+}
+
+Future<void> _publishTxtRecord(
+  String managementUrl,
+  String host,
+  String value,
+) async {
+  final managementClient = Dio();
+  await managementClient.post<void>(
+    '$managementUrl/set-txt',
+    data: json.encode({'host': host, 'value': value}),
+    options: Options(headers: {'Content-Type': 'application/json'}),
+  );
+}
+
+Dio _buildPebbleDio(String? trustedRootPath) => Dio()
+  ..httpClientAdapter = IOHttpClientAdapter(
+    createHttpClient: () {
+      final context = SecurityContext();
+      if (trustedRootPath != null && trustedRootPath.isNotEmpty) {
+        context.setTrustedCertificates(trustedRootPath);
+      }
+      final client = HttpClient(context: context);
+      if (trustedRootPath == null || trustedRootPath.isEmpty) {
+        client.badCertificateCallback = (certificate, host, port) => true;
+      }
+      return client;
+    },
+  );

--- a/test/dns_persist_pebble_test.dart
+++ b/test/dns_persist_pebble_test.dart
@@ -23,8 +23,6 @@ void main() {
       Platform.environment[_pebbleBaseUrlEnv] ?? 'https://localhost:14000/dir';
   final managementUrl =
       Platform.environment[_pebbleManagementUrlEnv] ?? 'http://localhost:8055';
-  final identifier =
-      Platform.environment[_pebbleIdentifierEnv] ?? 'example.com';
   final trustedRootPath = Platform.environment[_pebbleTrustedRootEnv];
 
   late Directory tmpDir;
@@ -42,28 +40,16 @@ void main() {
   });
 
   test(
-    'Pebble dns-persist-01 end-to-end',
+    'automated dns-persist-01 issuance',
     () async {
-      final certificatesHandler = CertificatesHandlerIO(
-        Directory(pack_path.join(tmpDir.path, 'certs')),
-      );
-      final letsEncrypt = LetsEncrypt(
+      final identifier = _identifier('automated', Platform.environment);
+      final certificatesHandler = _certificatesHandler(tmpDir);
+      final letsEncrypt = _letsEncrypt(
         certificatesHandler,
-        selfTest: false,
-        challengeType: LetsEncryptChallengeType.dnsPersist,
-        acmeDirectoryUrl: baseUrl,
-        acmeConnection: AcmeConnection(
-          baseUrl: baseUrl,
-          dio: _buildPebbleDio(trustedRootPath),
-        ),
-        dnsPersistChallengePublisher: (domainName, proof) async {
-          expect(domainName, identifier);
-          await _publishTxtRecord(
-            managementUrl,
-            proof.txtRecordName,
-            proof.txtRecordValue,
-          );
-        },
+        baseUrl: baseUrl,
+        managementUrl: managementUrl,
+        trustedRootPath: trustedRootPath,
+        expectedIdentifier: identifier,
       );
 
       final ok = await letsEncrypt.requestCertificate(
@@ -71,17 +57,196 @@ void main() {
       );
 
       expect(ok, isTrue);
-      final fullChainFile = certificatesHandler.fileDomainFullChainPEM(
-        identifier,
+      _expectStoredCertificate(certificatesHandler, identifier);
+    },
+    skip: enabled
+        ? false
+        : 'Set $_pebbleEnabledEnv=true to run against the local Pebble harness.',
+  );
+
+  test(
+    'manual dns-persist-01 prepare and complete',
+    () async {
+      final identifier = _identifier('manual', Platform.environment);
+      final certificatesHandler = _certificatesHandler(tmpDir);
+      final letsEncrypt = _letsEncrypt(
+        certificatesHandler,
+        baseUrl: baseUrl,
+        managementUrl: managementUrl,
+        trustedRootPath: trustedRootPath,
       );
-      expect(fullChainFile.existsSync(), isTrue);
-      expect(fullChainFile.readAsStringSync(), contains('BEGIN CERTIFICATE'));
+      final pending = await letsEncrypt.prepareDnsPersistCertificateRequest(
+        Domain(name: identifier, email: 'contact@$identifier'),
+      );
+
+      expect(pending.domainName, identifier);
+      await _publishTxtRecord(
+        managementUrl,
+        pending.proof.txtRecordName,
+        pending.proof.txtRecordValue,
+      );
+
+      expect(await pending.complete(), isTrue);
+      expect(await pending.complete(), isTrue);
+      _expectStoredCertificate(certificatesHandler, identifier);
+    },
+    skip: enabled
+        ? false
+        : 'Set $_pebbleEnabledEnv=true to run against the local Pebble harness.',
+  );
+
+  test(
+    'manual dns-persist-01 forced certificate request',
+    () async {
+      final identifier = _identifier('manual-force', Platform.environment);
+      final certificatesHandler = _certificatesHandler(tmpDir);
+      final letsEncrypt = _letsEncrypt(
+        certificatesHandler,
+        baseUrl: baseUrl,
+        managementUrl: managementUrl,
+        trustedRootPath: trustedRootPath,
+      );
+
+      final first = await letsEncrypt.prepareDnsPersistCertificateRequest(
+        Domain(name: identifier, email: 'contact@$identifier'),
+      );
+      await _publishTxtRecord(
+        managementUrl,
+        first.proof.txtRecordName,
+        first.proof.txtRecordValue,
+      );
+      expect(await first.complete(), isTrue);
+
+      final second = await letsEncrypt.prepareDnsPersistCertificateRequest(
+        Domain(name: identifier, email: 'contact@$identifier'),
+      );
+      await _publishTxtRecord(
+        managementUrl,
+        second.proof.txtRecordName,
+        second.proof.txtRecordValue,
+      );
+      expect(
+        await second.complete(forceRequestCertificate: true),
+        isTrue,
+      );
+      _expectStoredCertificate(certificatesHandler, identifier);
+    },
+    skip: enabled
+        ? false
+        : 'Set $_pebbleEnabledEnv=true to run against the local Pebble harness.',
+  );
+
+  test(
+    'checkCertificate force renews through dns-persist-01',
+    () async {
+      final identifier = _identifier('renewal', Platform.environment);
+      final certificatesHandler = _certificatesHandler(tmpDir);
+      final letsEncrypt = _letsEncrypt(
+        certificatesHandler,
+        baseUrl: baseUrl,
+        managementUrl: managementUrl,
+        trustedRootPath: trustedRootPath,
+        expectedIdentifier: identifier,
+      );
+      final domain = Domain(name: identifier, email: 'contact@$identifier');
+
+      expect(await letsEncrypt.requestCertificate(domain), isTrue);
+      final status = await letsEncrypt.checkCertificate(
+        domain,
+        requestCertificate: true,
+        forceRequestCertificate: true,
+        maxRetries: 1,
+      );
+
+      expect(status, CheckCertificateStatus.okRefreshed);
+      _expectStoredCertificate(certificatesHandler, identifier);
+    },
+    skip: enabled
+        ? false
+        : 'Set $_pebbleEnabledEnv=true to run against the local Pebble harness.',
+  );
+
+  test(
+    'dns-persist-01 fails when TXT record is missing',
+    () async {
+      final identifier = _identifier('missing-txt', Platform.environment);
+      final certificatesHandler = _certificatesHandler(tmpDir);
+      final letsEncrypt = _letsEncrypt(
+        certificatesHandler,
+        baseUrl: baseUrl,
+        managementUrl: managementUrl,
+        trustedRootPath: trustedRootPath,
+        expectedIdentifier: identifier,
+        publishRecord: false,
+      );
+
+      await expectLater(
+        () => letsEncrypt.requestCertificate(
+          Domain(name: identifier, email: 'contact@$identifier'),
+        ),
+        throwsA(anything),
+      );
+      expect(
+        certificatesHandler.fileDomainFullChainPEM(identifier).existsSync(),
+        isFalse,
+      );
     },
     skip: enabled
         ? false
         : 'Set $_pebbleEnabledEnv=true to run against the local Pebble harness.',
   );
 }
+
+CertificatesHandlerIO _certificatesHandler(Directory tmpDir) =>
+    CertificatesHandlerIO(
+      Directory(pack_path.join(tmpDir.path, 'certs')),
+    );
+
+LetsEncrypt _letsEncrypt(
+  CertificatesHandler certificatesHandler, {
+  required String baseUrl,
+  required String managementUrl,
+  required String? trustedRootPath,
+  String? expectedIdentifier,
+  bool publishRecord = true,
+}) =>
+    LetsEncrypt(
+      certificatesHandler,
+      selfTest: false,
+      challengeType: LetsEncryptChallengeType.dnsPersist,
+      acmeDirectoryUrl: baseUrl,
+      acmeConnection: AcmeConnection(
+        baseUrl: baseUrl,
+        dio: _buildPebbleDio(trustedRootPath),
+      ),
+      dnsPersistChallengePublisher: (domainName, proof) async {
+        if (expectedIdentifier != null) {
+          expect(domainName, expectedIdentifier);
+        }
+        if (!publishRecord) {
+          return;
+        }
+        await _publishTxtRecord(
+          managementUrl,
+          proof.txtRecordName,
+          proof.txtRecordValue,
+        );
+      },
+    );
+
+void _expectStoredCertificate(
+  CertificatesHandlerIO certificatesHandler,
+  String identifier,
+) {
+  final fullChainFile = certificatesHandler.fileDomainFullChainPEM(
+    identifier,
+  );
+  expect(fullChainFile.existsSync(), isTrue);
+  expect(fullChainFile.readAsStringSync(), contains('BEGIN CERTIFICATE'));
+}
+
+String _identifier(String prefix, Map<String, String> environment) =>
+    environment[_pebbleIdentifierEnv] ?? '$prefix.example.com';
 
 Future<void> _publishTxtRecord(
   String managementUrl,
@@ -91,10 +256,12 @@ Future<void> _publishTxtRecord(
   final managementClient = Dio();
   await managementClient.post<void>(
     '$managementUrl/set-txt',
-    data: json.encode({'host': host, 'value': value}),
+    data: json.encode({'host': _normalizeTxtHost(host), 'value': value}),
     options: Options(headers: {'Content-Type': 'application/json'}),
   );
 }
+
+String _normalizeTxtHost(String host) => host.endsWith('.') ? host : '$host.';
 
 Dio _buildPebbleDio(String? trustedRootPath) => Dio()
   ..httpClientAdapter = IOHttpClientAdapter(

--- a/test/shelf_letsencrypt_test.dart
+++ b/test/shelf_letsencrypt_test.dart
@@ -70,6 +70,7 @@ void main() {
       final letsEncrypt = LetsEncrypt(certificatesHandler);
 
       expect(letsEncrypt.production, isFalse);
+      expect(letsEncrypt.challengeType, LetsEncryptChallengeType.http);
 
       expect(letsEncrypt.apiBaseURL,
           allOf(contains('letsencrypt.org'), contains('staging')));
@@ -80,6 +81,53 @@ void main() {
       );
 
       expect(checkCertificateStatus, equals(CheckCertificateStatus.invalid));
+    });
+
+    test('dns-persist configuration', () async {
+      final certificatesHandler = CertificatesHandlerIO(
+          Directory(pack_path.join(tmpDir.path, 'certs-dns-persist')));
+
+      final publishedProofs = <String>[];
+      final letsEncrypt = LetsEncrypt(
+        certificatesHandler,
+        challengeType: LetsEncryptChallengeType.dnsPersist,
+        dnsPersistChallengePublisher: (domainName, proof) {
+          publishedProofs.add('$domainName ${proof.txtRecordName}');
+        },
+      );
+
+      expect(
+        letsEncrypt.challengeType,
+        LetsEncryptChallengeType.dnsPersist,
+      );
+      expect(letsEncrypt.dnsPersistChallengePublisher, isNotNull);
+      expect(publishedProofs, isEmpty);
+    });
+
+    test('dns-persist manual flow guidance', () async {
+      final certificatesHandler = CertificatesHandlerIO(
+          Directory(pack_path.join(tmpDir.path, 'certs-dns-persist-manual')));
+
+      final letsEncrypt = LetsEncrypt(
+        certificatesHandler,
+        challengeType: LetsEncryptChallengeType.dnsPersist,
+      );
+
+      await expectLater(
+        () => letsEncrypt.requestCertificate(
+          const Domain(name: 'example.com', email: 'contact@example.com'),
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            allOf(
+              contains('prepareDnsPersistCertificateRequest'),
+              contains('dnsPersistChallengePublisher'),
+            ),
+          ),
+        ),
+      );
     });
 
     test('ACME path + processACMEChallengeRequest', () async {

--- a/test/shelf_letsencrypt_test.dart
+++ b/test/shelf_letsencrypt_test.dart
@@ -1,7 +1,11 @@
 // ignore_for_file: avoid_catches_without_on_clauses
+// ignore_for_file: invalid_use_of_internal_member
 
+import 'dart:async';
 import 'dart:io';
 
+import 'package:acme_client/acme_client.dart'
+    show DnsPersistChallenge, DnsPersistChallengeProof, DomainIdentifier;
 import 'package:basic_utils/basic_utils.dart' hide Domain;
 import 'package:path/path.dart' as pack_path;
 import 'package:shelf/shelf.dart';
@@ -104,13 +108,14 @@ void main() {
       expect(publishedProofs, isEmpty);
     });
 
-    test('dns-persist manual flow guidance', () async {
+    test('dns-persist without publisher requires self-test', () async {
       final certificatesHandler = CertificatesHandlerIO(
           Directory(pack_path.join(tmpDir.path, 'certs-dns-persist-manual')));
 
       final letsEncrypt = LetsEncrypt(
         certificatesHandler,
         challengeType: LetsEncryptChallengeType.dnsPersist,
+        selfTest: false,
       );
 
       await expectLater(
@@ -122,12 +127,114 @@ void main() {
             (error) => error.message,
             'message',
             allOf(
+              contains('selfTest disabled'),
               contains('prepareDnsPersistCertificateRequest'),
               contains('dnsPersistChallengePublisher'),
             ),
           ),
         ),
       );
+    });
+
+    test('pending dns-persist complete shares successful completion', () async {
+      final gate = Completer<bool>();
+      var calls = 0;
+      final pending = PendingDnsPersistRequest.internal(
+        domainName: 'example.com',
+        proof: _dnsPersistProof(),
+        complete: ({bool forceRequestCertificate = false}) {
+          calls++;
+          return gate.future;
+        },
+      );
+
+      final first = pending.complete();
+      final second = pending.complete();
+      expect(identical(first, second), isTrue);
+      expect(calls, equals(1));
+
+      gate.complete(true);
+      expect(await first, isTrue);
+      expect(await second, isTrue);
+
+      final third = pending.complete();
+      expect(identical(first, third), isTrue);
+      expect(await third, isTrue);
+      expect(calls, equals(1));
+    });
+
+    test('pending dns-persist complete retries after failure', () async {
+      var calls = 0;
+      final pending = PendingDnsPersistRequest.internal(
+        domainName: 'example.com',
+        proof: _dnsPersistProof(),
+        complete: ({bool forceRequestCertificate = false}) {
+          calls++;
+          if (calls == 1) {
+            return Future<bool>.error(StateError('first attempt failed'));
+          }
+          return Future.value(true);
+        },
+      );
+
+      try {
+        await pending.complete();
+        fail('Expected first completion attempt to fail');
+      } catch (error) {
+        expect(error, isA<StateError>());
+      }
+      expect(await pending.complete(), isTrue);
+      expect(calls, equals(2));
+    });
+
+    test('pending dns-persist complete retries after timeout', () async {
+      var calls = 0;
+      final pending = PendingDnsPersistRequest.internal(
+        domainName: 'example.com',
+        proof: _dnsPersistProof(),
+        complete: ({bool forceRequestCertificate = false}) {
+          calls++;
+          if (calls == 1) {
+            return Future<bool>.delayed(
+              const Duration(seconds: 1),
+              () => true,
+            );
+          }
+          return Future.value(true);
+        },
+      );
+
+      try {
+        await pending.complete(timeout: const Duration(milliseconds: 1));
+        fail('Expected first completion attempt to time out');
+      } on TimeoutException {
+        // Expected. A timed out completion must not poison later retries.
+      }
+
+      expect(await pending.complete(), isTrue);
+      expect(calls, equals(2));
+    });
+
+    test('pending dns-persist complete can be forced', () async {
+      var calls = 0;
+      final pending = PendingDnsPersistRequest.internal(
+        domainName: 'example.com',
+        proof: _dnsPersistProof(),
+        complete: ({bool forceRequestCertificate = false}) {
+          calls++;
+          return Future.value(forceRequestCertificate);
+        },
+      );
+
+      expect(await pending.complete(), isFalse);
+      expect(await pending.complete(), isFalse);
+      expect(calls, equals(1));
+
+      expect(
+        await pending.complete(forceRequestCertificate: true),
+        isTrue,
+      );
+      expect(calls, equals(2));
     });
 
     test('ACME path + processACMEChallengeRequest', () async {
@@ -254,3 +361,13 @@ void main() {
     });
   });
 }
+
+DnsPersistChallengeProof _dnsPersistProof() =>
+    DnsPersistChallengeProof.forAuthorization(
+      domainIdentifier: const DomainIdentifier('example.com'),
+      challenge: DnsPersistChallenge(
+        issuerDomainNames: const ['issuer.example.com'],
+      ),
+      issuerDomainName: 'issuer.example.com',
+      accountUri: 'https://acme.example/acct/1',
+    );


### PR DESCRIPTION
This pull is perhaps a little ahead of things:
dns-persist-01 is supported by LE staging but not production as well as the pebble docker container.

I've raised a PR against acme_client which supports dns-persist-01 - this is a very large refactor so there is a chance it won't be accepted - we will deal with that when it comes.

https://github.com/Ephenodrom/Dart-Acme-Client/pull/12

As dns-persist-01 requires manual intervention - the user needs to add the txt record to their dns server - I'm not certain that I've got the startup flow around this correct. I've added a cli tool under tools to facilitate. 
We could automate this process by providing implementations for multiple dns providers but I'm not keen on the ongoing support work that will engender.

anyway, have a look and let me know what you think.
